### PR TITLE
Catch KeyError when looking for reactions for thermoMatch species

### DIFF
--- a/importChemkin.py
+++ b/importChemkin.py
@@ -2463,7 +2463,10 @@ $('#thermomatches_count').html("("+json.thermomatches+")");
                 
             output.append("<tr><td>{num} Reactions</td>".format(num=len(chemkinReactions)))
             for matchingSpecies in sortedMatchingSpeciesList:
-                output.append("<td>{n}</td>".format(n=len(possibleMatches[matchingSpecies])))
+                try:
+                    output.append("<td>{n}</td>".format(n=len(possibleMatches[matchingSpecies])))
+                except KeyError:
+                    output.append("<td>{n}</td>".format(n=0))
             output.append("</tr>")
                 
             for chemkinReaction in sorted(chemkinReactions, key=lambda rxn:-len(myVotingChemkinReactions[rxn])):


### PR DESCRIPTION
Species that have a thermo match, but no matching reactions should still show up, but throw an error since they have no matching reactions. This should catch those errors.